### PR TITLE
Fix the parameters order problems when invoke in MCP Inspector v0.12.0

### DIFF
--- a/src/main/java/com/github/codeboyzhou/mcp/declarative/server/McpSyncServerPromptRegister.java
+++ b/src/main/java/com/github/codeboyzhou/mcp/declarative/server/McpSyncServerPromptRegister.java
@@ -29,7 +29,7 @@ public class McpSyncServerPromptRegister
     @Override
     public void registerTo(McpSyncServer server) {
         for (Class<?> promptClass : promptClasses) {
-            Set<Method> methods = ReflectionHelper.getMethodsAnnotatedWith(promptClass, McpPrompt.class);
+            List<Method> methods = ReflectionHelper.getMethodsAnnotatedWith(promptClass, McpPrompt.class);
             for (Method method : methods) {
                 McpServerFeatures.SyncPromptSpecification prompt = createComponentFrom(promptClass, method);
                 server.addPrompt(prompt);
@@ -59,7 +59,7 @@ public class McpSyncServerPromptRegister
     }
 
     private List<McpSchema.PromptArgument> createPromptArguments(Method method) {
-        Set<Parameter> parameters = ReflectionHelper.getParametersAnnotatedWith(method, McpPromptParam.class);
+        List<Parameter> parameters = ReflectionHelper.getParametersAnnotatedWith(method, McpPromptParam.class);
         List<McpSchema.PromptArgument> promptArguments = new ArrayList<>(parameters.size());
         for (Parameter parameter : parameters) {
             McpPromptParam promptParam = parameter.getAnnotation(McpPromptParam.class);

--- a/src/main/java/com/github/codeboyzhou/mcp/declarative/server/McpSyncServerResourceRegister.java
+++ b/src/main/java/com/github/codeboyzhou/mcp/declarative/server/McpSyncServerResourceRegister.java
@@ -26,7 +26,7 @@ public class McpSyncServerResourceRegister
     @Override
     public void registerTo(McpSyncServer server) {
         for (Class<?> resourceClass : resourceClasses) {
-            Set<Method> methods = ReflectionHelper.getMethodsAnnotatedWith(resourceClass, McpResource.class);
+            List<Method> methods = ReflectionHelper.getMethodsAnnotatedWith(resourceClass, McpResource.class);
             for (Method method : methods) {
                 McpServerFeatures.SyncResourceSpecification resource = createComponentFrom(resourceClass, method);
                 server.addResource(resource);

--- a/src/main/java/com/github/codeboyzhou/mcp/declarative/server/McpSyncServerToolRegister.java
+++ b/src/main/java/com/github/codeboyzhou/mcp/declarative/server/McpSyncServerToolRegister.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,7 +33,7 @@ public class McpSyncServerToolRegister
     @Override
     public void registerTo(McpSyncServer server) {
         for (Class<?> toolClass : toolClasses) {
-            Set<Method> methods = ReflectionHelper.getMethodsAnnotatedWith(toolClass, McpTool.class);
+            List<Method> methods = ReflectionHelper.getMethodsAnnotatedWith(toolClass, McpTool.class);
             for (Method method : methods) {
                 McpServerFeatures.SyncToolSpecification tool = createComponentFrom(toolClass, method);
                 server.addTool(tool);
@@ -63,10 +63,11 @@ public class McpSyncServerToolRegister
     }
 
     private McpSchema.JsonSchema createJsonSchema(Method method) {
-        Map<String, Object> properties = new HashMap<>();
+        //has to use linkedhashmap to make order correct
+        Map<String, Object> properties = new LinkedHashMap<>();
         List<String> required = new ArrayList<>();
 
-        Set<Parameter> parameters = ReflectionHelper.getParametersAnnotatedWith(method, McpToolParam.class);
+        List<Parameter> parameters = ReflectionHelper.getParametersAnnotatedWith(method, McpToolParam.class);
         for (Parameter parameter : parameters) {
             McpToolParam toolParam = parameter.getAnnotation(McpToolParam.class);
             final String parameterName = toolParam.name();

--- a/src/main/java/com/github/codeboyzhou/mcp/declarative/util/ReflectionHelper.java
+++ b/src/main/java/com/github/codeboyzhou/mcp/declarative/util/ReflectionHelper.java
@@ -5,22 +5,34 @@ import io.modelcontextprotocol.spec.McpSchema;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
-import static java.util.stream.Collectors.toSet;
+import java.util.stream.Stream;
 
 public final class ReflectionHelper {
 
-    public static Set<Method> getMethodsAnnotatedWith(Class<?> clazz, Class<? extends Annotation> annotation) {
+    /**
+     * has to use list as result to make order correct
+     * @param clazz
+     * @param annotation
+     * @return
+     */
+    public static List<Method> getMethodsAnnotatedWith(Class<?> clazz, Class<? extends Annotation> annotation) {
         Method[] methods = clazz.getMethods();
-        return Set.of(methods).stream().filter(m -> m.isAnnotationPresent(annotation)).collect(toSet());
+        return Stream.of(methods).filter(m -> m.isAnnotationPresent(annotation)).toList();
     }
 
-    public static Set<Parameter> getParametersAnnotatedWith(Method method, Class<? extends Annotation> annotation) {
+    /**
+     * has to use list as result to make order correct
+     * @param method
+     * @param annotation
+     * @return
+     */
+    public static List<Parameter> getParametersAnnotatedWith(Method method, Class<? extends Annotation> annotation) {
         Parameter[] parameters = method.getParameters();
-        return Set.of(parameters).stream().filter(p -> p.isAnnotationPresent(annotation)).collect(toSet());
+        return Stream.of(parameters).filter(p -> p.isAnnotationPresent(annotation)).toList();
     }
 
     public static Object invokeMethod(Class<?> clazz, Method method) throws Exception {


### PR DESCRIPTION
There are problems when invoke in MCP Inspector page, the parameters order show in page is error. And it cause the annotation not work correct when call method.invoke()
![image](https://github.com/user-attachments/assets/843822a9-e5d6-420a-bfa0-c543517ecc60)
